### PR TITLE
Add slevomat coding standard to phpcs paths

### DIFF
--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -26,6 +26,7 @@ RUN composer require --prefer-dist \
         "squizlabs/php_codesniffer:^3.3" \
         "drupal/coder:^8.3.7" \
         "phpcompatibility/php-compatibility:^9.3" \
+        "slevomat/coding-standard": "^7.0" \
     && \
     git clone https://git.drupalcode.org/sandbox/coltrane-1921926.git drupalsecure && \
     git clone https://github.com/klausi/pareviewsh.git && \
@@ -37,7 +38,7 @@ RUN rm $TOOLBOX_TARGET_DIR/phpcs && \
     ln -s $TARGET_DIR/vendor/bin/phpcs $TOOLBOX_TARGET_DIR && \
     ln -s $TARGET_DIR/pareviewsh/pareview.sh $TOOLBOX_TARGET_DIR/pareview && \
     chmod +x $TOOLBOX_TARGET_DIR/pareview && \
-    phpcs --config-set installed_paths $TARGET_DIR/vendor/drupal/coder/coder_sniffer/,$TARGET_DIR/vendor/phpcompatibility/php-compatibility,$TARGET_DIR/drupalsecure
+    phpcs --config-set installed_paths $TARGET_DIR/vendor/drupal/coder/coder_sniffer/,$TARGET_DIR/vendor/phpcompatibility/php-compatibility,$TARGET_DIR/drupalsecure,$TARGET_DIR/vendor/slevomat/coding-standard/
 
 COPY tool-drupal-check.json /tool-drupal-check.json
 

--- a/7.3/debian/Dockerfile
+++ b/7.3/debian/Dockerfile
@@ -26,7 +26,7 @@ RUN composer require --prefer-dist \
         "squizlabs/php_codesniffer:^3.3" \
         "drupal/coder:^8.3.7" \
         "phpcompatibility/php-compatibility:^9.3" \
-        "slevomat/coding-standard": "^7.0" \
+        "slevomat/coding-standard:^7.0" \
     && \
     git clone https://git.drupalcode.org/sandbox/coltrane-1921926.git drupalsecure && \
     git clone https://github.com/klausi/pareviewsh.git && \

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -26,6 +26,7 @@ RUN composer require --prefer-dist \
         "squizlabs/php_codesniffer:^3.5" \
         "drupal/coder:^8.3.7" \
         "phpcompatibility/php-compatibility:^9.3" \
+        "slevomat/coding-standard": "^7.0" \
     && \
     git clone https://git.drupalcode.org/sandbox/coltrane-1921926.git drupalsecure && \
     git clone https://github.com/klausi/pareviewsh.git && \
@@ -37,7 +38,7 @@ RUN rm $TOOLBOX_TARGET_DIR/phpcs && \
     ln -s $TARGET_DIR/vendor/bin/phpcs $TOOLBOX_TARGET_DIR && \
     ln -s $TARGET_DIR/pareviewsh/pareview.sh $TOOLBOX_TARGET_DIR/pareview && \
     chmod +x $TOOLBOX_TARGET_DIR/pareview && \
-    phpcs --config-set installed_paths $TARGET_DIR/vendor/drupal/coder/coder_sniffer/,$TARGET_DIR/vendor/phpcompatibility/php-compatibility,$TARGET_DIR/drupalsecure
+    phpcs --config-set installed_paths $TARGET_DIR/vendor/drupal/coder/coder_sniffer/,$TARGET_DIR/vendor/phpcompatibility/php-compatibility,$TARGET_DIR/drupalsecure,$TARGET_DIR/vendor/slevomat/coding-standard/
 
 COPY tool-drupal-check.json /tool-drupal-check.json
 

--- a/7.4/debian/Dockerfile
+++ b/7.4/debian/Dockerfile
@@ -26,7 +26,7 @@ RUN composer require --prefer-dist \
         "squizlabs/php_codesniffer:^3.5" \
         "drupal/coder:^8.3.7" \
         "phpcompatibility/php-compatibility:^9.3" \
-        "slevomat/coding-standard": "^7.0" \
+        "slevomat/coding-standard:^7.0" \
     && \
     git clone https://git.drupalcode.org/sandbox/coltrane-1921926.git drupalsecure && \
     git clone https://github.com/klausi/pareviewsh.git && \


### PR DESCRIPTION
Explicitly add [`slevomat/coding-standard`](https://github.com/slevomat/coding-standard) to our `composer require` to avoid errors in case coder decides to remove it again. In any case, it seems to be a popular ruleset and is valuable to the image.

Fixes #4

