### PR TITLE
Support PHP 8.5

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['8.2', '8.3', '8.4']
+        php_version: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout repository
@@ -43,8 +43,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             hussainweb/drupalqa:php${{ matrix.php_version }}
-            ${{ matrix.php_version == '8.4' && 'hussainweb/drupalqa:latest' || '' }}
+            ${{ matrix.php_version == '8.5' && 'hussainweb/drupalqa:latest' || '' }}
             ghcr.io/hussainweb/drupalqa:php${{ matrix.php_version }}
-            ${{ matrix.php_version == '8.4' && 'ghcr.io/hussainweb/drupalqa:latest' || '' }}
+            ${{ matrix.php_version == '8.5' && 'ghcr.io/hussainweb/drupalqa:latest' || '' }}
           build-args: |
             PHP_VERSION=php${{ matrix.php_version }}

--- a/8.x/debian/Dockerfile
+++ b/8.x/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=php8.3
+ARG PHP_VERSION=php8.5
 FROM jakzal/phpqa:${PHP_VERSION}
 
 LABEL maintainer="hussainweb@gmail.com"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 DockerHub repository: [https://hub.docker.com/r/hussainweb/drupalqa](https://hub.docker.com/r/hussainweb/drupalqa)
 
-This image currently only supports Debian along with 8.2, 8.3, and 8.4. Older images are available but no longer supported by the [upstream image](https://github.com/jakzal/phpqa/).
+This image currently only supports Debian along with 8.2, 8.3, 8.4, and 8.5. Older images are available but no longer supported by the [upstream image](https://github.com/jakzal/phpqa/).
 
 ### Debian
 
@@ -19,6 +19,7 @@ This image currently only supports Debian along with 8.2, 8.3, and 8.4. Older im
 - `php8.2` ([8.x/debian/Dockerfile](8.x/debian/Dockerfile))
 - `php8.3` ([8.x/debian/Dockerfile](8.x/debian/Dockerfile))
 - `php8.4` ([8.x/debian/Dockerfile](8.x/debian/Dockerfile))
+- `php8.5` ([8.x/debian/Dockerfile](8.x/debian/Dockerfile))
 
 ## Available Tools
 

--- a/build.sh
+++ b/build.sh
@@ -11,17 +11,20 @@ docker pull jakzal/phpqa:php8.1
 docker pull jakzal/phpqa:php8.2
 docker pull jakzal/phpqa:php8.3
 docker pull jakzal/phpqa:php8.4
+docker pull jakzal/phpqa:php8.5
 
 docker build -t hussainweb/drupalqa:php8.0 --build-arg PHP_VERSION=php8.0 ${dir}/8.x/debian/
 docker build -t hussainweb/drupalqa:php8.1 --build-arg PHP_VERSION=php8.1 ${dir}/8.x/debian/
 docker build -t hussainweb/drupalqa:php8.2 --build-arg PHP_VERSION=php8.2 ${dir}/8.x/debian/
 docker build -t hussainweb/drupalqa:php8.3 --build-arg PHP_VERSION=php8.3 ${dir}/8.x/debian/
-docker build -t hussainweb/drupalqa:php8.3 --build-arg PHP_VERSION=php8.4 ${dir}/8.x/debian/
-docker tag hussainweb/drupalqa:php8.4 hussainweb/drupalqa:latest
+docker build -t hussainweb/drupalqa:php8.4 --build-arg PHP_VERSION=php8.4 ${dir}/8.x/debian/
+docker build -t hussainweb/drupalqa:php8.5 --build-arg PHP_VERSION=php8.5 ${dir}/8.x/debian/
+docker tag hussainweb/drupalqa:php8.5 hussainweb/drupalqa:latest
 
 docker push hussainweb/drupalqa:php8.0
 docker push hussainweb/drupalqa:php8.1
 docker push hussainweb/drupalqa:php8.2
 docker push hussainweb/drupalqa:php8.3
 docker push hussainweb/drupalqa:php8.4
+docker push hussainweb/drupalqa:php8.5
 docker push hussainweb/drupalqa:latest

--- a/clean.sh
+++ b/clean.sh
@@ -5,10 +5,12 @@ docker rmi jakzal/phpqa:php8.1
 docker rmi jakzal/phpqa:php8.2
 docker rmi jakzal/phpqa:php8.3
 docker rmi jakzal/phpqa:php8.4
+docker rmi jakzal/phpqa:php8.5
 
 docker rmi hussainweb/drupalqa:php8.0
 docker rmi hussainweb/drupalqa:php8.1
 docker rmi hussainweb/drupalqa:php8.2
 docker rmi hussainweb/drupalqa:php8.3
 docker rmi hussainweb/drupalqa:php8.4
+docker rmi hussainweb/drupalqa:php8.5
 docker rmi hussainweb/drupalqa:latest


### PR DESCRIPTION
Added support for PHP 8.5 by updating the build matrix in `.github/workflows/docker.yml`, build scripts, and documentation. Also fixed a bug in `build.sh` where the PHP 8.4 image was being tagged incorrectly.

Closes #16.

---
*PR created automatically by Jules for task [15410689916073640870](https://jules.google.com/task/15410689916073640870) started by @hussainweb*